### PR TITLE
build: fix corepack issue (https://github.com/nodejs/corepack/issues/612) in Dockerfile (properly ig)

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -21,8 +21,10 @@
 
 FROM node:20-alpine AS base
 RUN apk update && apk add --no-cache curl
-RUN corepack disable
-RUN npm install -g pnpm@9.0.0
+# early, build was failing because corepack cannot find matching keyid
+# ref: https://github.com/nodejs/corepack/issues/612
+RUN npm i -g corepack@latest
+RUN corepack enable pnpm
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 


### PR DESCRIPTION
In previous commits, I avoided the issue by disabling corepack entirely and pinning the pnpm version while installing it with npm. This approach should be better as it's [recommended by pnpm](https://web.archive.org/web/20250208023914/https://pnpm.io/installation#using-corepack)