### PR TITLE
fix: remove light mode style from magic card

### DIFF
--- a/apps/web/src/components/card/magic-card.tsx
+++ b/apps/web/src/components/card/magic-card.tsx
@@ -45,7 +45,7 @@ export function MagicCard({
       onMouseMove={handleMouseMove}
       onMouseLeave={handleMouseLeave}
       className={cn(
-        "group relative flex size-full overflow-hidden rounded-xl bg-neutral-100 text-black dark:bg-neutral-900 dark:text-white",
+        "group relative flex size-full overflow-hidden rounded-xl bg-neutral-900 text-white",
         className,
       )}
     >


### PR DESCRIPTION
On device with preferred light mode, magic card appeared in white background which is not intended. This pr fix that. 